### PR TITLE
Inner input should always be full width of parent

### DIFF
--- a/src/input/README.md
+++ b/src/input/README.md
@@ -11,7 +11,7 @@ The `Input` component creates an input that can be invalidated.
       label="Email Address"
       type="email"
       width="280px"
-      id="tonic-input-example"
+      id="example-input"
       placeholder="Enter a valid email address"
       spellcheck="false"
       error-message="Invalid Email">

--- a/src/input/index.js
+++ b/src/input/index.js
@@ -156,7 +156,7 @@ class TonicInput extends Tonic { /* global Tonic */
 
   renderLabel () {
     if (!this.props.label) return ''
-    return `<label>${this.props.label}</label>`
+    return `<label for="tonic--input_${this.props.id}">${this.props.label}</label>`
   }
 
   renderIcon () {
@@ -250,6 +250,7 @@ class TonicInput extends Tonic { /* global Tonic */
 
   render () {
     const {
+      id,
       width,
       height,
       type,
@@ -268,6 +269,7 @@ class TonicInput extends Tonic { /* global Tonic */
       tabindex
     } = this.props
 
+    const idAttr = id ? `id="tonic--input_${id}"` : ''
     const patternAttr = pattern ? `pattern="${pattern}"` : ''
     const placeholderAttr = placeholder ? `placeholder="${placeholder}"` : ''
     const spellcheckAttr = spellcheck ? `spellcheck="${spellcheck}"` : ''
@@ -291,6 +293,7 @@ class TonicInput extends Tonic { /* global Tonic */
     const valueAttr = value && value !== 'undefined' ? `value="${value}"` : ''
 
     const attributes = [
+      idAttr,
       patternAttr,
       valueAttr,
       placeholderAttr,

--- a/src/input/index.js
+++ b/src/input/index.js
@@ -4,7 +4,6 @@ class TonicInput extends Tonic { /* global Tonic */
       type: 'text',
       value: '',
       placeholder: '',
-      width: '250px',
       color: 'var(--tonic-primary)',
       spellcheck: false,
       ariaInvalid: false,
@@ -240,7 +239,7 @@ class TonicInput extends Tonic { /* global Tonic */
         width
       },
       input: {
-        width,
+        width: '100%',
         height,
         borderRadius: radius,
         padding
@@ -251,7 +250,6 @@ class TonicInput extends Tonic { /* global Tonic */
   render () {
     const {
       id,
-      width,
       height,
       type,
       placeholder,
@@ -285,7 +283,6 @@ class TonicInput extends Tonic { /* global Tonic */
     const tabAttr = tabindex ? `tabindex="${tabindex}"` : ''
     if (tabindex) this.removeAttribute('tabindex')
 
-    if (width) this.style.width = width
     if (height) this.style.width = height
     if (theme) this.classList.add(`tonic--theme--${theme}`)
 


### PR DESCRIPTION
Previously, if you set an `tonic-input` width to `50%`, it would set the inner input element also to `50%`, resulting in a `25%` wide input. 

Therefore the inner input should always be `100%` of the parent.